### PR TITLE
Upstream Ubuntu for docs, Python 3.11 is released.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
         # queries: security-extended,security-and-quality
 
         
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Deploy documentation
 on: 
-  #push:
-    #branches: [main]
+  # push:
+    # branches: [main]
   workflow_dispatch:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -25,15 +25,15 @@ jobs:
         uses: actions/configure-pages@v2
         # This is specifically configured to use the latest stable version of Python
         # Assuming we support it
-      - name: Setup Python 3.10
+      - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: 3.11
       # mkdocs' gh-deploy command uses the 'legacy' method of deploying custom sites to Pages
       # which is placing the built files on a gh-pages branch with a .nojekyll.
-      # (source: https://github.com/mkdocs/mkdocs/blob/master/mkdocs/commands/gh_deploy.py#L127)
+      # (Source: https://github.com/mkdocs/mkdocs/blob/master/mkdocs/commands/gh_deploy.py#L127)
       # Since then, GitHub has released a way to deploy to Pages directly from Actions.
-      # Which makes our life a lot easier.
+      # Which makes our lifes a lot easier.
       - name: Install dependencies and build
         run: |
           python -m venv .
@@ -45,7 +45,7 @@ jobs:
           path: site/
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,7 +16,7 @@ jobs:
           "3.8",
           "3.9",
           "3.10",
-          "3.11.0-rc.2"
+          "3.11"
         ]
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     steps:
@@ -32,16 +32,15 @@ jobs:
         path: ~/.local/share/virtualenvs
         key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
     - name: Install dependencies and analyze the code
-      if: matrix.python-version != '3.11.0-rc.2' 
+      if: matrix.python-version != '3.11.0' 
       run: |
         python -m pip install pipenv pylint
 
         cd ./envs/${{ matrix.python-version }}
         pipenv install
         pipenv run cd ../../vanilla-installer && pylint . --rcfile pylint.toml
-    # This is temporary until 3.11 is fully released and can be referenced by `3.11`.
     - name: Install dependencies and analyze the code (3.11)
-      if: matrix.python-version == '3.11.0-rc.2'
+      if: matrix.python-version == '3.11'
       run: |
         echo "Using 3.11 workaround."
         python -m pip install pipenv pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,12 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [
-          "3.8",
-          "3.9",
-          "3.10",
-          "3.11"
-        ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +27,7 @@ jobs:
         path: ~/.local/share/virtualenvs
         key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
     - name: Install dependencies and analyze the code
-      if: matrix.python-version != '3.11.0' 
+      if: matrix.python-version != '3.11' 
       run: |
         python -m pip install pipenv pylint
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -34,12 +34,3 @@ jobs:
         cd ./envs/${{ matrix.python-version }}
         pipenv install
         pipenv run cd ../../vanilla-installer && pylint . --rcfile pylint.toml
-    - name: Install dependencies and analyze the code (3.11)
-      if: matrix.python-version == '3.11'
-      run: |
-        echo "Using 3.11 workaround."
-        python -m pip install pipenv pylint
-
-        cd ./envs/${{ matrix.python-version }}
-        pipenv install
-        pipenv run cd ../../vanilla-installer && pylint . --rcfile pylint.toml


### PR DESCRIPTION
This updates python from the second RC build to the finalized build of 3.11, however this requires upstreaming the main library tools as this results in workflow errors but help is welcomed.