### PR TITLE
Update dependencies for pyproject.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ asyncclick = "^8.1.3.4"
 anyio = "^3.6.2" # asyncclick seems to bug without anyio
 
 [tool.poetry.group.dev.dependencies]
-pylint = "^2.15.4"
+pylint = "^2.15.6"
 black = "^22.10.0"
-# cx-Freeze = "^6.13.0"
+# cx-Freeze = "^6.13.1"
 # install cx-Freeze manually on python < 3.11
 # however official [release] builds will be built on python >=3.11
 # (this is a workaround until cx-Freeze releases 6.14.0)
@@ -37,7 +37,7 @@ cx-freeze = {url = "https://marcelotduarte.github.io/packages/cx-freeze/cx_Freez
 
 
 [tool.poetry.group.ci.dependencies]
-flake8 = "^5.0.4"
+flake8 = "^6.0.0"
 
 [tool.poetry.scripts]
 vanilla-installer = {callable = "vanilla_installer:cli.vanilla_installer"}


### PR DESCRIPTION
Pylint has been updated from 2.15.4 -> 2.15.6,
cx-Freeze has been updated from 6.13.0 -> 6.13.1,
and flake0 has been updated from 5.0.4 -> 6.0.0.

Tests are suggested to ensure the new tools are functioning as intended.