### PR TITLE
Update devcontainer to Ubuntu 22.04.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
   "features": {
     /* "ghcr.io/devcontainers/features/python:1": {
       "installTools": true


### PR DESCRIPTION
This updates ubuntu from 20.04 LTS in Microsoft's devcontainer to 22.04 LTS.