### PR TITLE
Skip Git-Repo-Sync on PRs entirely.

### DIFF
--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync-bitbucket:
+    if: github.repository_owner == 'Fabulously-Optimized'
     runs-on: ubuntu-22.04
     name: Git Repo Sync - BitBucket
     steps:


### PR DESCRIPTION
This allows other pull requests to be properly checked without having to see BitBucket constantly failing in them all the time unless the sync task is inside the actual repository itself then we let it run there instead.

CC: @Madis0 - If tested and merged, Please include this in your other repos in same organization whenever possible.