### PR TITLE
Add error for when there is only an incompatible version of Python installed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -194,3 +194,5 @@ do
     exit $?
 
 done
+echoerr "Error: No compatible versions of Python could be found. Get Python from https://www.python.org/downloads or with your system package manager."
+exit 1


### PR DESCRIPTION
Right now you do not get any prompt to install Python if there is already a pre-existing (but incompatible) install.

![image](https://github.com/Fabulously-Optimized/vanilla-installer/assets/44583181/83c7ac12-f0bd-47c5-bc5d-5f86e59f1f55)

This PR aims to fix that.
